### PR TITLE
Fix jupyterlite-core dependency version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -27,7 +27,7 @@ requirements:
     - python >={{ python_min }}
     - empack >=5.1.1,<7
     - traitlets
-    - jupyterlite-core >=0.7,<0.8
+    - jupyterlite-core >=0.7,<0.9
     - pyyaml
     - requests
     # This is a hard-dependency now (cannot be for PyPi)


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This corrects the version of the `jupyterlite-core` dependency to match that of the upstream [pyproject.toml](https://github.com/jupyterlite/xeus/blob/000e2dc1a59709887bff16a0399617965f09ac36/pyproject.toml#L28), i.e. `>=0.7,<0.9`.